### PR TITLE
Fix project name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'octopusteamcityplugin'
+rootProject.name = 'teamcity-opentelemetry-plugin'
 include ':server'
 include ':common'
 


### PR DESCRIPTION
# Background

The repo used to be `opentelemetry-teamcity-plugin`, but my mind always thought of "teamcity" first, so I've renamed it to be `teamcity-opentelemetry-plugin` to make more sense.

# Results

This PR renames the gradle rootproject to match.