### PR TITLE
Fixes after repo-rename

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -6,7 +6,7 @@
 
 <!-- Describe the result of the change including a link to any resolved issues. -->
 
-Fixes https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin /issues/...
+Fixes https://github.com/OctopusDeploy/teamcity-opentelemetry-plugin /issues/...
 
 <!-- Consider adding a before/after log excerpt or screen capture. -->
 

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -48,7 +48,7 @@ step "create-github-release" {
             GHCR_ContentType = "application/zip"
             GHCR_Draft = "False"
             GHCR_GitHubApiKey = "#{GitHubAccessToken}"
-            GHCR_GitHubRepository = "opentelemetry-teamcity-plugin"
+            GHCR_GitHubRepository = "teamcity-opentelemetry-plugin"
             GHCR_GitHubUsername = "OctopusDeploy"
             GHCR_PackageId = "{\"PackageId\":\"Octopus.TeamCity.OpenTelemetry\",\"FeedId\":\"octopus-server-built-in\"}"
             GHCR_PreRelease = "#{IsPreRelease}"


### PR DESCRIPTION
# Background

After the repo was renamed, I missed a few spots where the old repo was mentioned.

# Results

Renames to the new name