### PR TITLE
Increase throughput of the BatchSpanProcessor

### DIFF
--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -1,5 +1,7 @@
 package com.octopus.teamcity.opentelemetry.common;
 
+import java.time.Duration;
+
 public class PluginConstants {
     private PluginConstants() {}
     public static final String TRACER_INSTRUMENTATION_NAME = "octopus.teamcity.opentelemetry";
@@ -15,6 +17,9 @@ public class PluginConstants {
     public static final String PROPERTY_KEY_HONEYCOMB_APIKEY = "octopus.teamcity.opentelemetry.plugin.honeycomb.apikey";
     public static final String PROPERTY_KEY_HONEYCOMB_METRICS_ENABLED = "octopus.teamcity.opentelemetry.plugin.honeycomb.metrics.enabled";
 
+    public static final int BATCH_SPAN_PROCESSOR_MAX_QUEUE_SIZE = 32768; // Default is 2048. Increasing it to limit dropped spans.
+    public static final Duration BATCH_SPAN_PROCESSOR_MAX_SCHEDULE_DELAY = Duration.ofSeconds(5); // Default is 5s. This is another lever we can tweak.
+    public static final int BATCH_SPAN_PROCESSOR_MAX_EXPORT_BATCH_SIZE = 8192; // Default is 512. Increasing it to limit dropped spans.
 
     public static final String ATTRIBUTE_SERVICE_NAME = "service_name";
     public static final String ATTRIBUTE_NAME = "name";

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/custom/CustomOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/custom/CustomOTELEndpointHandler.java
@@ -81,6 +81,10 @@ public class CustomOTELEndpointHandler implements IOTELEndpointHandler {
         LOG.debug("OTEL_PLUGIN: Opentelemetry export headers: " + LogMasker.mask(headers.toString()));
         LOG.debug("OTEL_PLUGIN: Opentelemetry export endpoint: " + exporterEndpoint);
 
-        return BatchSpanProcessor.builder(spanExporter).build();
+        return BatchSpanProcessor.builder(spanExporter)
+                .setMaxQueueSize(BATCH_SPAN_PROCESSOR_MAX_QUEUE_SIZE)
+                .setScheduleDelay(BATCH_SPAN_PROCESSOR_MAX_SCHEDULE_DELAY)
+                .setMaxExportBatchSize(BATCH_SPAN_PROCESSOR_MAX_EXPORT_BATCH_SIZE)
+                .build();
     }
 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
@@ -95,9 +95,9 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
                 .build();
 
         return BatchSpanProcessor.builder(spanExporter)
-                .setMaxQueueSize(32768) // Default is 2048. Increasing it to limit dropped spans.
-                .setScheduleDelay(Duration.ofSeconds(5)) // Default is 5s. This is another lever we can tweak.
-                .setMaxExportBatchSize(8192) // Default is 512. Increasing it to limit dropped spans.
+                .setMaxQueueSize(BATCH_SPAN_PROCESSOR_MAX_QUEUE_SIZE)
+                .setScheduleDelay(BATCH_SPAN_PROCESSOR_MAX_SCHEDULE_DELAY)
+                .setMaxExportBatchSize(BATCH_SPAN_PROCESSOR_MAX_EXPORT_BATCH_SIZE)
                 .setMeterProvider(meterProvider)
                 .build();
     }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
@@ -94,7 +94,12 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
                 .setMeterProvider(meterProvider)
                 .build();
 
-        return BatchSpanProcessor.builder(spanExporter).build();
+        return BatchSpanProcessor.builder(spanExporter)
+                .setMaxQueueSize(32768) // Default is 2048. Increasing it to limit dropped spans.
+                .setScheduleDelay(Duration.ofSeconds(5)) // Default is 5s. This is another lever we can tweak.
+                .setMaxExportBatchSize(8192) // Default is 512. Increasing it to limit dropped spans.
+                .setMeterProvider(meterProvider)
+                .build();
     }
 
     @Override

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipKinOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipKinOTELEndpointHandler.java
@@ -13,7 +13,7 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
-import static com.octopus.teamcity.opentelemetry.common.PluginConstants.PROPERTY_KEY_ENDPOINT;
+import static com.octopus.teamcity.opentelemetry.common.PluginConstants.*;
 
 public class ZipKinOTELEndpointHandler implements IOTELEndpointHandler {
     private final PluginDescriptor pluginDescriptor;
@@ -44,7 +44,11 @@ public class ZipKinOTELEndpointHandler implements IOTELEndpointHandler {
                 .setEndpoint(endpoint)
                 .build();
 
-        return BatchSpanProcessor.builder(zipkinExporter).build();
+        return BatchSpanProcessor.builder(zipkinExporter)
+                .setMaxQueueSize(BATCH_SPAN_PROCESSOR_MAX_QUEUE_SIZE)
+                .setScheduleDelay(BATCH_SPAN_PROCESSOR_MAX_SCHEDULE_DELAY)
+                .setMaxExportBatchSize(BATCH_SPAN_PROCESSOR_MAX_EXPORT_BATCH_SIZE)
+                .build();
     }
 
     @Override


### PR DESCRIPTION
# Background

The metrics shipped with #339 helped to prove that we were dropping spans.

[sc-96078]

# Results

This bumps up the batch size and queue size, which will allow large traces to be shipped without dropping spans.

In future, we may want to make these configurable via env var/system property, but for now, I'm hardcoding.

## Before

Dropped spans (the green line):
![image](https://github.com/user-attachments/assets/dca8c13b-e41f-4dca-95a3-98616aa6c8e8)

![image](https://github.com/user-attachments/assets/7c943b03-923f-488e-bc7f-b6c1182469c3)


## After

No more dropped spans (the green line):
![image](https://github.com/user-attachments/assets/c9e64b5b-8a68-4c65-9f6f-5089e0bc9c1e)

![image](https://github.com/user-attachments/assets/b7cde274-2f03-4baa-b37b-d193f748ffe4)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.