### PR TITLE
Fix capitalisation of zipkin

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/OTELEndpointFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/OTELEndpointFactory.java
@@ -2,7 +2,7 @@ package com.octopus.teamcity.opentelemetry.server.endpoints;
 
 import com.octopus.teamcity.opentelemetry.server.endpoints.custom.CustomOTELEndpointHandler;
 import com.octopus.teamcity.opentelemetry.server.endpoints.honeycomb.HoneycombOTELEndpointHandler;
-import com.octopus.teamcity.opentelemetry.server.endpoints.zipkin.ZipKinOTELEndpointHandler;
+import com.octopus.teamcity.opentelemetry.server.endpoints.zipkin.ZipkinOTELEndpointHandler;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,7 +30,7 @@ public class OTELEndpointFactory {
             case HONEYCOMB:
                 return new HoneycombOTELEndpointHandler(pluginDescriptor);
             case ZIPKIN:
-                return new ZipKinOTELEndpointHandler(pluginDescriptor);
+                return new ZipkinOTELEndpointHandler(pluginDescriptor);
             case CUSTOM:
                 return new CustomOTELEndpointHandler(pluginDescriptor);
             default:

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipkinOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipkinOTELEndpointHandler.java
@@ -15,10 +15,10 @@ import java.util.Map;
 
 import static com.octopus.teamcity.opentelemetry.common.PluginConstants.*;
 
-public class ZipKinOTELEndpointHandler implements IOTELEndpointHandler {
+public class ZipkinOTELEndpointHandler implements IOTELEndpointHandler {
     private final PluginDescriptor pluginDescriptor;
 
-    public ZipKinOTELEndpointHandler(
+    public ZipkinOTELEndpointHandler(
             PluginDescriptor pluginDescriptor) {
         this.pluginDescriptor = pluginDescriptor;
     }


### PR DESCRIPTION
# Background

I happened to see Zipkin capitalised as `ZipKin`.

# Results

This PR fixes that.