### PR TITLE
Dont use globals for the tc metrics settings

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/IOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/IOTELEndpointHandler.java
@@ -1,8 +1,11 @@
 package com.octopus.teamcity.opentelemetry.server.endpoints;
 
 import com.octopus.teamcity.opentelemetry.server.SetProjectConfigurationSettingsRequest;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
+import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -11,7 +14,7 @@ import java.util.Map;
 public interface IOTELEndpointHandler {
     ModelAndView getBuildOverviewModelAndView(SBuild build, Map<String, String> params, String traceId);
 
-    SpanProcessor buildSpanProcessor(String endpoint, Map<String, String> params);
+    Pair<SpanProcessor, SdkMeterProvider> buildSpanProcessorAndMeterProvider(BuildPromotion buildPromotion, String endpoint, Map<String, String> params);
 
     SetProjectConfigurationSettingsRequest getSetProjectConfigurationSettingsRequest(HttpServletRequest request);
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/custom/CustomOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/custom/CustomOTELEndpointHandler.java
@@ -4,12 +4,15 @@ import com.octopus.teamcity.opentelemetry.server.*;
 import com.octopus.teamcity.opentelemetry.server.endpoints.IOTELEndpointHandler;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.crypt.EncryptUtil;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -34,7 +37,7 @@ public class CustomOTELEndpointHandler implements IOTELEndpointHandler {
     }
 
     @Override
-    public SpanProcessor buildSpanProcessor(String endpoint, Map<String, String> params) {
+    public Pair<SpanProcessor, SdkMeterProvider> buildSpanProcessorAndMeterProvider(BuildPromotion buildPromotion, String endpoint, Map<String, String> params) {
         Map<String, String> headers = new HashMap<>();
         params.forEach((k, v) -> {
             if (k.startsWith(PROPERTY_KEY_HEADERS)) {
@@ -44,7 +47,7 @@ public class CustomOTELEndpointHandler implements IOTELEndpointHandler {
                 headers.put(name, value);
             }
         });
-        return buildGrpcSpanProcessor(headers, endpoint);
+        return Pair.of(buildGrpcSpanProcessor(headers, endpoint), null);
     }
 
     @Override

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
@@ -81,7 +81,6 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
                     .addHeader("x-honeycomb-team", EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY)))
                     .addHeader("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET))
                     .build();
-                otlpGrpcMetricExporterBuilder.addHeader("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
             }
         }
         return null;

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
@@ -66,8 +66,6 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
         Map<String, String> headers = new HashMap<>();
         //todo: add a setting to say "use classic" or "use environments"
         headers.put("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
-        if (!Objects.equals(params.get(PROPERTY_KEY_HONEYCOMB_MODE), HONEYCOMB_MODE_ENVIRONMENTS)) {
-            headers.put("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
         headers.put("x-honeycomb-team", EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY)));
 
         var metricsExporter = buildMetricsExporter(endpoint, params);

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
@@ -81,7 +81,6 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
                     .addHeader("x-honeycomb-team", EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY)))
                     .addHeader("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET))
                     .build();
-            }
         }
         return null;
     }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
@@ -4,25 +4,28 @@ import com.octopus.teamcity.opentelemetry.common.PluginConstants;
 import com.octopus.teamcity.opentelemetry.server.*;
 import com.octopus.teamcity.opentelemetry.server.endpoints.IOTELEndpointHandler;
 import com.octopus.teamcity.opentelemetry.server.helpers.OTELMetrics;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.crypt.EncryptUtil;
 import jetbrains.buildServer.serverSide.crypt.RSACipher;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
-import java.time.Duration;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,15 +62,17 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
     }
 
     @Override
-    public SpanProcessor buildSpanProcessor(String endpoint, Map<String, String> params) {
+    public Pair<SpanProcessor, SdkMeterProvider> buildSpanProcessorAndMeterProvider(BuildPromotion buildPromotion, String endpoint, Map<String, String> params) {
         Map<String, String> headers = new HashMap<>();
         //todo: add a setting to say "use classic" or "use environments"
         headers.put("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
+        if (!Objects.equals(params.get(PROPERTY_KEY_HONEYCOMB_MODE), HONEYCOMB_MODE_ENVIRONMENTS)) {
+            headers.put("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
         headers.put("x-honeycomb-team", EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY)));
 
         var metricsExporter = buildMetricsExporter(endpoint, params);
 
-        return buildGrpcSpanProcessor(headers, endpoint, metricsExporter);
+        return buildGrpcSpanProcessor(buildPromotion, headers, endpoint, metricsExporter);
     }
 
     @Nullable
@@ -78,28 +83,41 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
                     .addHeader("x-honeycomb-team", EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY)))
                     .addHeader("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET))
                     .build();
+                otlpGrpcMetricExporterBuilder.addHeader("x-honeycomb-dataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
+            }
         }
         return null;
     }
 
-    private SpanProcessor buildGrpcSpanProcessor(Map<String, String> headers, String exporterEndpoint, @Nullable MetricExporter metricsExporter) {
+    private Pair<SpanProcessor, SdkMeterProvider> buildGrpcSpanProcessor(BuildPromotion buildPromotion, Map<String, String> headers, String exporterEndpoint, @Nullable MetricExporter metricsExporter) {
 
-        var serviceNameResource = Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, PluginConstants.SERVICE_NAME));
+        //todo: centralise the definition of this
+        var serviceNameResource = Resource
+                .create(Attributes.of(
+                        ResourceAttributes.SERVICE_NAME, PluginConstants.SERVICE_NAME,
+                        AttributeKey.stringKey("teamcity.build_promotion.id"), Long.toString(buildPromotion.getId())
+                        //todo: add teamcity node name
+                        //ResourceAttributes.NODE_NAME, PluginConstants.SERVICE_NAME
+                ));
+
         var meterProvider = OTELMetrics.getOTELMeterProvider(metricsExporter, serviceNameResource);
 
         var spanExporterBuilder = OtlpGrpcSpanExporter.builder();
+        spanExporterBuilder.setEndpoint(exporterEndpoint);
         headers.forEach(spanExporterBuilder::addHeader);
-        var spanExporter = spanExporterBuilder
-                .setEndpoint(exporterEndpoint)
-                .setMeterProvider(meterProvider)
-                .build();
+        if (meterProvider != null) {
+            spanExporterBuilder.setMeterProvider(meterProvider);
+        }
+        var spanExporter = spanExporterBuilder.build();
 
-        return BatchSpanProcessor.builder(spanExporter)
-                .setMaxQueueSize(BATCH_SPAN_PROCESSOR_MAX_QUEUE_SIZE)
-                .setScheduleDelay(BATCH_SPAN_PROCESSOR_MAX_SCHEDULE_DELAY)
-                .setMaxExportBatchSize(BATCH_SPAN_PROCESSOR_MAX_EXPORT_BATCH_SIZE)
-                .setMeterProvider(meterProvider)
-                .build();
+        var batchSpanProcessorBuilder = BatchSpanProcessor.builder(spanExporter);
+        batchSpanProcessorBuilder.setMaxQueueSize(BATCH_SPAN_PROCESSOR_MAX_QUEUE_SIZE);
+        batchSpanProcessorBuilder.setScheduleDelay(BATCH_SPAN_PROCESSOR_MAX_SCHEDULE_DELAY);
+        batchSpanProcessorBuilder.setMaxExportBatchSize(BATCH_SPAN_PROCESSOR_MAX_EXPORT_BATCH_SIZE);
+        if (meterProvider != null) {
+            batchSpanProcessorBuilder.setMeterProvider(meterProvider);
+        }
+        return Pair.of(batchSpanProcessorBuilder.build(), meterProvider);
     }
 
     @Override

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipKinOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipKinOTELEndpointHandler.java
@@ -3,10 +3,13 @@ package com.octopus.teamcity.opentelemetry.server.endpoints.zipkin;
 import com.octopus.teamcity.opentelemetry.server.SetProjectConfigurationSettingsRequest;
 import com.octopus.teamcity.opentelemetry.server.endpoints.IOTELEndpointHandler;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -34,8 +37,8 @@ public class ZipKinOTELEndpointHandler implements IOTELEndpointHandler {
     }
 
     @Override
-    public SpanProcessor buildSpanProcessor(String endpoint, Map<String, String> params) {
-        return buildZipkinSpanProcessor(endpoint);
+    public Pair<SpanProcessor, SdkMeterProvider> buildSpanProcessorAndMeterProvider(BuildPromotion buildPromotion, String endpoint, Map<String, String> params) {
+        return Pair.of(buildZipkinSpanProcessor(endpoint), null);
     }
 
     private SpanProcessor buildZipkinSpanProcessor(String exporterEndpoint) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
@@ -1,6 +1,7 @@
 package com.octopus.teamcity.opentelemetry.server.helpers;
 
 import com.octopus.teamcity.opentelemetry.server.endpoints.OTELEndpointFactory;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.ProjectManager;
@@ -43,13 +44,14 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
                 var params = feature.getParameters();
                 if (params.get(PROPERTY_KEY_ENABLED).equals("true")) {
                     var endpoint = params.get(PROPERTY_KEY_ENDPOINT);
-                    SpanProcessor spanProcessor;
 
                     var otelHandler = otelEndpointFactory.getOTELEndpointHandler(params.get(PROPERTY_KEY_SERVICE));
                     var spanProcessorMeterProviderPair = otelHandler.buildSpanProcessorAndMeterProvider(buildPromotion, endpoint, params);
 
                     long startTime = System.nanoTime();
-                    var otelHelper = new OTELHelperImpl(spanProcessorMeterProviderPair.getLeft(), spanProcessorMeterProviderPair.getRight(), String.valueOf(buildId));
+                    var spanProcessor = spanProcessorMeterProviderPair.getLeft();
+                    var meterProvider = spanProcessorMeterProviderPair.getRight();
+                    var otelHelper = new OTELHelperImpl(spanProcessor, meterProvider, String.valueOf(buildId));
                     long endTime = System.nanoTime();
 
                     long duration = (endTime - startTime);

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
@@ -26,8 +27,14 @@ public class OTELHelperImpl implements OTELHelper {
     private final ConcurrentHashMap<String, Span> spanMap;
     private final SdkTracerProvider sdkTracerProvider;
     private final String helperName;
+    @Nullable
+    private final SdkMeterProvider meterProvider;
 
-    public OTELHelperImpl(SpanProcessor spanProcessor, String helperName) {
+    public OTELHelperImpl(
+            SpanProcessor spanProcessor,
+            @Nullable
+            SdkMeterProvider meterProvider,
+            String helperName) {
         this.helperName = helperName;
         Resource serviceNameResource = Resource
                 .create(Attributes.of(ResourceAttributes.SERVICE_NAME, PluginConstants.SERVICE_NAME));
@@ -41,6 +48,7 @@ public class OTELHelperImpl implements OTELHelper {
                 .build();
         this.tracer = this.openTelemetry.getTracer(PluginConstants.TRACER_INSTRUMENTATION_NAME);
         this.spanMap = new ConcurrentHashMap<>();
+        this.meterProvider = meterProvider;
     }
 
     @Override
@@ -92,6 +100,8 @@ public class OTELHelperImpl implements OTELHelper {
 
         this.sdkTracerProvider.forceFlush();
         this.sdkTracerProvider.close();
+        if (this.meterProvider != null)
+            this.meterProvider.close();
         this.spanMap.clear();
     }
 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELMetrics.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELMetrics.java
@@ -1,7 +1,5 @@
 package com.octopus.teamcity.opentelemetry.server.helpers;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
@@ -9,37 +7,21 @@ import io.opentelemetry.sdk.resources.Resource;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class OTELMetrics {
 
-    private static final AtomicBoolean metricsConfigured = new AtomicBoolean(false);
-    private static SdkMeterProvider sdkMeterProvider;
-
-    // this is not quite right...
-    // it's using project level settings (which can be different across projects)
-    // but setting up a global configuration.
-    // likely need to refactor the config so that it has metrics configuration as global
-
+    @Nullable
     public static SdkMeterProvider getOTELMeterProvider(@Nullable MetricExporter metricExporter, Resource serviceNameResource) {
-        if (metricsConfigured.get()) return sdkMeterProvider;
-        metricsConfigured.set(true);
+        if (metricExporter == null) return null;
 
-        var meterProviderBuilder = SdkMeterProvider.builder()
-                .setResource(Resource.getDefault().merge(serviceNameResource));
-        if (metricExporter != null) {
-            var providedMetricExporterBuilder = PeriodicMetricReader.builder(metricExporter)
-                    .setInterval(Duration.ofSeconds(10))
-                    .build();
-            meterProviderBuilder
-                    .registerMetricReader(providedMetricExporterBuilder);
-        }
-        sdkMeterProvider = meterProviderBuilder.build();
-        var globalOpenTelemetry = OpenTelemetrySdk.builder()
-                .setMeterProvider(sdkMeterProvider)
+        var providedMetricExporter = PeriodicMetricReader.builder(metricExporter)
+                .setInterval(Duration.ofSeconds(10))
                 .build();
 
-        GlobalOpenTelemetry.set(globalOpenTelemetry);
+        var sdkMeterProvider = SdkMeterProvider.builder()
+                .setResource(Resource.getDefault().merge(serviceNameResource))
+                .registerMetricReader(providedMetricExporter)
+                .build();
 
         // Shutdown hooks to close resources properly
         Runtime.getRuntime().addShutdownHook(new Thread(sdkMeterProvider::close));

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELMetrics.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELMetrics.java
@@ -18,13 +18,9 @@ public class OTELMetrics {
                 .setInterval(Duration.ofSeconds(10))
                 .build();
 
-        var sdkMeterProvider = SdkMeterProvider.builder()
+        return SdkMeterProvider.builder()
                 .setResource(Resource.getDefault().merge(serviceNameResource))
                 .registerMetricReader(providedMetricExporter)
                 .build();
-
-        // Shutdown hooks to close resources properly
-        Runtime.getRuntime().addShutdownHook(new Thread(sdkMeterProvider::close));
-        return sdkMeterProvider;
     }
 }

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/OTELHelperTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/OTELHelperTest.java
@@ -32,7 +32,7 @@ class OTELHelperTest {
     @BeforeEach
     void setUp() {
         GlobalOpenTelemetry.resetForTest();
-        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS), "helperNamr");
+        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS), null, "helperNamr");
     }
 
 

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
@@ -33,7 +33,7 @@ class TeamCityBuildListenerTest {
     @BeforeEach
     void setUp(@Mock EventDispatcher<BuildServerListener> buildServerListenerEventDispatcher) {
         GlobalOpenTelemetry.resetForTest();
-        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS), "helper");
+        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS), null, "helper");
         this.factory = mock(OTELHelperFactory.class, RETURNS_DEEP_STUBS);
 
         var buildStorageManager = mock(BuildStorageManager.class, RETURNS_DEEP_STUBS);


### PR DESCRIPTION
# Background

I had success all during testing for the metrics shipping, but as soon as I merged and used the prod one, it stopped working.

<img width="646" alt="image" src="https://github.com/user-attachments/assets/89f7bc4c-a21d-4f38-929f-ceb25982470e">

Interestingly, it started working after teamcity was restarted due to cluster upgrade. This suggests to me that the global was getting into a bad state due to concurrency.

This is wise anyway, as we want to avoid the use of the global properties, as it allows metrics per project. 

[sc-96078]

# Results

We now:
* no longer set the GlobalOpenTelemetry config
* ~add an attribute to the metric, so we can see what build it relates to~ this was done in https://github.com/OctopusDeploy/teamcity-opentelemetry-plugin/pull/348.
* shutdown the metric reader, so that it doesn't leak threads

## After

![image](https://github.com/user-attachments/assets/f575cb14-326d-4844-b7d8-01d4cf004cd9)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.