### PR TITLE
Include teamcity node name in metrics

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/OTELEndpointFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/OTELEndpointFactory.java
@@ -3,6 +3,7 @@ package com.octopus.teamcity.opentelemetry.server.endpoints;
 import com.octopus.teamcity.opentelemetry.server.endpoints.custom.CustomOTELEndpointHandler;
 import com.octopus.teamcity.opentelemetry.server.endpoints.honeycomb.HoneycombOTELEndpointHandler;
 import com.octopus.teamcity.opentelemetry.server.endpoints.zipkin.ZipKinOTELEndpointHandler;
+import jetbrains.buildServer.serverSide.TeamCityNodes;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,11 +11,15 @@ public class OTELEndpointFactory {
 
     @NotNull
     private final PluginDescriptor pluginDescriptor;
+    @NotNull
+    private final TeamCityNodes teamcityNodesService;
 
     public OTELEndpointFactory(
-        @NotNull PluginDescriptor pluginDescriptor)
+            @NotNull PluginDescriptor pluginDescriptor,
+            @NotNull TeamCityNodes teamcityNodesService)
     {
         this.pluginDescriptor = pluginDescriptor;
+        this.teamcityNodesService = teamcityNodesService;
     }
 
     public IOTELEndpointHandler getOTELEndpointHandler(String otelService)
@@ -28,7 +33,7 @@ public class OTELEndpointFactory {
         switch (otelService)
         {
             case HONEYCOMB:
-                return new HoneycombOTELEndpointHandler(pluginDescriptor);
+                return new HoneycombOTELEndpointHandler(pluginDescriptor, teamcityNodesService);
             case ZIPKIN:
                 return new ZipKinOTELEndpointHandler(pluginDescriptor);
             case CUSTOM:

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/honeycomb/HoneycombOTELEndpointHandler.java
@@ -14,6 +14,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.semconv.ServiceAttributes;
 import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.TeamCityNodes;
 import jetbrains.buildServer.serverSide.crypt.EncryptUtil;
 import jetbrains.buildServer.serverSide.crypt.RSACipher;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
@@ -33,10 +34,12 @@ import static com.octopus.teamcity.opentelemetry.common.PluginConstants.*;
 public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
 
     private final PluginDescriptor pluginDescriptor;
+    private final TeamCityNodes nodesService;
     static Logger LOG = Logger.getLogger(HoneycombOTELEndpointHandler.class.getName());
 
-    public HoneycombOTELEndpointHandler(PluginDescriptor pluginDescriptor) {
+    public HoneycombOTELEndpointHandler(PluginDescriptor pluginDescriptor, TeamCityNodes nodesService) {
         this.pluginDescriptor = pluginDescriptor;
+        this.nodesService = nodesService;
     }
 
     @NotNull
@@ -88,7 +91,8 @@ public class HoneycombOTELEndpointHandler implements IOTELEndpointHandler {
         //todo: centralise the definition of this
         var serviceNameResource = Resource
                 .create(Attributes.of(
-                        ServiceAttributes.SERVICE_NAME, PluginConstants.SERVICE_NAME
+                        ServiceAttributes.SERVICE_NAME, PluginConstants.SERVICE_NAME,
+                        AttributeKey.stringKey("teamcity.node.id"), nodesService.getCurrentNode().getId()
                 ));
 
         var meterProvider = OTELMetrics.getOTELMeterProvider(metricsExporter, serviceNameResource);


### PR DESCRIPTION
# Background

Including the teamcity node name in the metrics will help us isolate primary/secondary (and hopefully preprod/prod, but I'm not sure about that).

# Results

Passes through the `NodesService` so we can log `teamcity.node.id`.

![image](https://github.com/user-attachments/assets/b1b66f9a-f9bf-4157-93bf-4c32b99a6506)

On my local (single node) setup, it logs it as `MAIN_SERVER`.
