### PR TITLE
Log build id with metrics

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/IOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/IOTELEndpointHandler.java
@@ -2,6 +2,7 @@ package com.octopus.teamcity.opentelemetry.server.endpoints;
 
 import com.octopus.teamcity.opentelemetry.server.SetProjectConfigurationSettingsRequest;
 import io.opentelemetry.sdk.trace.SpanProcessor;
+import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -11,7 +12,7 @@ import java.util.Map;
 public interface IOTELEndpointHandler {
     ModelAndView getBuildOverviewModelAndView(SBuild build, Map<String, String> params, String traceId);
 
-    SpanProcessor buildSpanProcessor(String endpoint, Map<String, String> params);
+    SpanProcessor buildSpanProcessor(BuildPromotion buildPromotion, String endpoint, Map<String, String> params);
 
     SetProjectConfigurationSettingsRequest getSetProjectConfigurationSettingsRequest(HttpServletRequest request);
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/custom/CustomOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/custom/CustomOTELEndpointHandler.java
@@ -7,6 +7,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.crypt.EncryptUtil;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
@@ -34,7 +35,7 @@ public class CustomOTELEndpointHandler implements IOTELEndpointHandler {
     }
 
     @Override
-    public SpanProcessor buildSpanProcessor(String endpoint, Map<String, String> params) {
+    public SpanProcessor buildSpanProcessor(BuildPromotion buildPromotion, String endpoint, Map<String, String> params) {
         Map<String, String> headers = new HashMap<>();
         params.forEach((k, v) -> {
             if (k.startsWith(PROPERTY_KEY_HEADERS)) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipKinOTELEndpointHandler.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/endpoints/zipkin/ZipKinOTELEndpointHandler.java
@@ -5,6 +5,7 @@ import com.octopus.teamcity.opentelemetry.server.endpoints.IOTELEndpointHandler;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +35,7 @@ public class ZipKinOTELEndpointHandler implements IOTELEndpointHandler {
     }
 
     @Override
-    public SpanProcessor buildSpanProcessor(String endpoint, Map<String, String> params) {
+    public SpanProcessor buildSpanProcessor(BuildPromotion buildPromotion, String endpoint, Map<String, String> params) {
         return buildZipkinSpanProcessor(endpoint);
     }
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
@@ -29,12 +29,12 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
         this.otelHelpers = new ConcurrentHashMap<>();
     }
 
-    public OTELHelper getOTELHelper(BuildPromotion build) {
-        var buildId = build.getId();
+    public OTELHelper getOTELHelper(BuildPromotion buildPromotion) {
+        var buildId = buildPromotion.getId();
 
         return otelHelpers.computeIfAbsent(buildId, key -> {
             LOG.debug(String.format("Creating OTELHelper for build %d.", buildId));
-            var projectId = build.getProjectExternalId();
+            var projectId = buildPromotion.getProjectExternalId();
             var project = projectManager.findProjectByExternalId(projectId);
 
             var features = project.getAvailableFeaturesOfType(PLUGIN_NAME);
@@ -46,7 +46,7 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
                     SpanProcessor spanProcessor;
 
                     var otelHandler = otelEndpointFactory.getOTELEndpointHandler(params.get(PROPERTY_KEY_SERVICE));
-                    spanProcessor = otelHandler.buildSpanProcessor(endpoint, params);
+                    spanProcessor = otelHandler.buildSpanProcessor(buildPromotion, endpoint, params);
 
                     long startTime = System.nanoTime();
                     var otelHelper = new OTELHelperImpl(spanProcessor, String.valueOf(buildId));


### PR DESCRIPTION
# Background

It's useful to know at the metrics level, which builds are related.

# Results

Adds `teamcity.build_promotion.id` (which maps 1:1 with buildId) to the metrics emitted.

![image](https://github.com/user-attachments/assets/79a8e873-080d-4855-9ccb-71fadff85cee)
