### PR TITLE
Slight logging tweaks

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildOverviewExtensionController.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildOverviewExtensionController.java
@@ -74,7 +74,7 @@ public class BuildOverviewExtensionController extends BaseController
 
         Long buildId = WebUtil.sakuraUIOpened(request)
             ? PluginUIContext.getFromRequest(request).getBuildId()
-            : Long.valueOf(Long.parseLong(request.getParameter("buildId")));
+            : Long.parseLong(request.getParameter("buildId"));
 
         if (buildId != null) {
             try (var ignored1 = CloseableThreadContext.put("teamcity.build.id", String.valueOf(buildId))) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildOverviewExtensionController.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildOverviewExtensionController.java
@@ -8,6 +8,7 @@ import jetbrains.buildServer.serverSide.SBuildServer;
 import jetbrains.buildServer.serverSide.SProject;
 import jetbrains.buildServer.web.openapi.*;
 import jetbrains.buildServer.web.util.WebUtil;
+import org.apache.logging.log4j.CloseableThreadContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.web.servlet.ModelAndView;
@@ -73,29 +74,32 @@ public class BuildOverviewExtensionController extends BaseController
 
         Long buildId = WebUtil.sakuraUIOpened(request)
             ? PluginUIContext.getFromRequest(request).getBuildId()
-            : Long.parseLong(request.getParameter("buildId"));
+            : Long.valueOf(Long.parseLong(request.getParameter("buildId")));
 
         if (buildId != null) {
-            final SBuild build = sBuildServer.findBuildInstanceById(buildId);
-            if (build == null) //if it's queued, we won't get it
-                return getEmptyState();
+            try (var ignored1 = CloseableThreadContext.put("teamcity.build.id", String.valueOf(buildId))) {
 
-            final SProject project = projectManager.findProjectByExternalId(build.getProjectExternalId());
-
-            var features = project.getAvailableFeaturesOfType(PLUGIN_NAME);
-            if (!features.isEmpty()) {
-                var feature = features.stream().findFirst().get();
-                var params = feature.getParameters();
-
-                if (!params.get(PROPERTY_KEY_ENABLED).equals("true"))
+                final SBuild build = sBuildServer.findBuildInstanceById(buildId);
+                if (build == null) //if it's queued, we won't get it
                     return getEmptyState();
 
-                var traceId = buildStorageManager.getTraceId(build);
-                if (traceId == null)
-                    return getEmptyState();
+                final SProject project = projectManager.findProje   ctByExternalId(build.getProjectExternalId());
 
-                var service = otelEndpointFactory.getOTELEndpointHandler(params.get(PROPERTY_KEY_SERVICE));
-                return service.getBuildOverviewModelAndView(build, params, traceId);
+                var features = project.getAvailableFeaturesOfType(PLUGIN_NAME);
+                if (!features.isEmpty()) {
+                    var feature = features.stream().findFirst().get();
+                    var params = feature.getParameters();
+
+                    if (!params.get(PROPERTY_KEY_ENABLED).equals("true"))
+                        return getEmptyState();
+
+                    var traceId = buildStorageManager.getTraceId(build);
+                    if (traceId == null)
+                        return getEmptyState();
+
+                    var service = otelEndpointFactory.getOTELEndpointHandler(params.get(PROPERTY_KEY_SERVICE));
+                    return service.getBuildOverviewModelAndView(build, params, traceId);
+                }
             }
         }
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildOverviewExtensionController.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildOverviewExtensionController.java
@@ -83,7 +83,7 @@ public class BuildOverviewExtensionController extends BaseController
                 if (build == null) //if it's queued, we won't get it
                     return getEmptyState();
 
-                final SProject project = projectManager.findProje   ctByExternalId(build.getProjectExternalId());
+                final SProject project = projectManager.findProjectByExternalId(build.getProjectExternalId());
 
                 var features = project.getAvailableFeaturesOfType(PLUGIN_NAME);
                 if (!features.isEmpty()) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildStorageManagerImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildStorageManagerImpl.java
@@ -23,7 +23,7 @@ public class BuildStorageManagerImpl implements BuildStorageManager {
         File artifactsDir = build.getArtifactsDirectory();
         File pluginFile = new File(artifactsDir, jetbrains.buildServer.ArtifactsConstants.TEAMCITY_ARTIFACTS_DIR + File.separatorChar + OTEL_TRACE_ID_FILENAME);
 
-        LOG.debug(String.format("Reading trace id or build %d.", build.getBuildId()));
+        LOG.debug(String.format("Reading trace id for build %d.", build.getBuildId()));
 
         if (!pluginFile.exists()) {
             LOG.info(String.format("Unable to find build artifact %s for build %d.", OTEL_TRACE_ID_FILENAME, build.getBuildId()));


### PR DESCRIPTION
# Background

I noticed a few (super low priority) issues with these logs:

![image](https://github.com/user-attachments/assets/a3aa05d2-0a57-42dc-9434-2e2d94f7cb6c)

* it's not including the build id as an attribute
* it should be `for`, not `or`.

