### PR TITLE
Cache OTEL helper by project rather than build

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationSettingsController.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationSettingsController.java
@@ -1,6 +1,7 @@
 package com.octopus.teamcity.opentelemetry.server;
 
 import com.octopus.teamcity.opentelemetry.server.endpoints.OTELEndpointFactory;
+import com.octopus.teamcity.opentelemetry.server.helpers.OTELHelperFactory;
 import jetbrains.buildServer.controllers.ActionErrors;
 import jetbrains.buildServer.controllers.ActionMessages;
 import jetbrains.buildServer.controllers.BaseFormXmlController;
@@ -22,13 +23,17 @@ public class ProjectConfigurationSettingsController extends BaseFormXmlControlle
     private final ProjectManager projectManager;
     static Logger LOG = Logger.getLogger(ProjectConfigurationSettingsController.class.getName());
     private final OTELEndpointFactory otelEndpointFactory;
+    @NotNull
+    private final OTELHelperFactory otelHelperFactory;
 
     public ProjectConfigurationSettingsController(
             @NotNull ProjectManager projectManager,
             @NotNull WebControllerManager controllerManager,
-            @NotNull OTELEndpointFactory otelEndpointFactory) {
+            @NotNull OTELEndpointFactory otelEndpointFactory,
+            @NotNull OTELHelperFactory otelHelperFactory) {
         this.projectManager = projectManager;
         this.otelEndpointFactory = otelEndpointFactory;
+        this.otelHelperFactory = otelHelperFactory;
 
         controllerManager.registerController("/admin/" + PLUGIN_NAME + "/settings.html", this);
     }
@@ -57,8 +62,8 @@ public class ProjectConfigurationSettingsController extends BaseFormXmlControlle
             return;
         }
 
-        //todo: tell the OTELHelperFactory that project settings have changed.
-        //      this would allow us to change the factory to cache based on project, rather than on build
+        //tell the OTELHelperFactory that project settings have changed, so it can update its cache
+        otelHelperFactory.settingsUpdated(project);
 
         var feature = project.getOwnFeaturesOfType(PLUGIN_NAME);
         if (settingsRequest.mode.isPresent() && settingsRequest.mode.get().equals(SaveMode.RESET)) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -218,11 +218,8 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                         span.setStatus(StatusCode.ERROR, PluginConstants.EXCEPTION_ERROR_MESSAGE_DURING_BUILD_FINISH + ": " + e.getMessage());
                     } finally {
                         span.end();
-                        var buildId = getBuildId(build);
-                        otelHelper.removeSpan(buildId);
-                        if (buildId.equals(String.valueOf(getRootBuildInChain(build).getId())))
-                            otelHelperFactory.release(build.getBuildId());
-                    }
+                        otelHelper.removeSpan(getBuildId(build));
+                   }
                 } else {
                     LOG.warn("Build end triggered but span not found for build '" + getBuildName(build) + "' id " + build.getBuildId());
                 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperFactory.java
@@ -1,10 +1,10 @@
 package com.octopus.teamcity.opentelemetry.server.helpers;
 
 import jetbrains.buildServer.serverSide.BuildPromotion;
-import jetbrains.buildServer.serverSide.SRunningBuild;
+import jetbrains.buildServer.serverSide.SProject;
 
 public interface OTELHelperFactory {
     OTELHelper getOTELHelper(BuildPromotion build);
 
-    void release(Long buildId);
+    void settingsUpdated(SProject project);
 }

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
@@ -121,23 +121,4 @@ class TeamCityBuildListenerTest {
         // Assert
         assertNull(this.otelHelper.getSpan(String.valueOf(build.getBuildId())));
     }
-
-    @Test
-    void buildFinishedOrInterruptedAsksFactoryToRelease() {
-        // Arrange
-        SRunningBuild build = mock(SRunningBuild.class, RETURNS_DEEP_STUBS);
-        // Stubbing this method to return the build if there is no parent, this is the behaviour of TeamCity
-        BuildPromotion[] buildPromotions = new BuildPromotion[]{build.getBuildPromotion()};
-        when(build.getBuildPromotion().findTops()).thenReturn(buildPromotions);
-        when(factory.getOTELHelper(Arrays.stream(buildPromotions).findFirst().get())).thenReturn(otelHelper);
-        when(teamCityNodes.getCurrentNode().isMainNode()).thenReturn(true);
-        this.buildListener.buildStarted(build);
-        assertNotNull(this.otelHelper.getSpan(String.valueOf(build.getBuildId())));
-
-        // Act
-        this.buildListener.buildFinished(build);
-
-        // Assert
-        verify(factory, times(1)).release(build.getBuildId());
-    }
 }


### PR DESCRIPTION
# Background

We were caching the `OTELHelper` by the build, as we weren't sure whether the settings would change between builds, so we wanted to lookup the settings at the start of each build.

However, this means we're creating a whole lot more OTEL things than we really need to, on the off chance it changes.

# Results

Turns out all we needed to do was remove the item from the cache when the project was updated, and we automatically get the updates.

So, now, we cache based on project, and create far fewer `BatchSpanProcessor_WorkerThread`, hopefully fixing #368.

:thinking: If an update happens while a build is running, half of the traces could go to the old settings, and new ones go to the new place, but that is probably okay. Probably.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.