### PR TITLE
Evict entries from the cache to release threads

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
@@ -3,11 +3,17 @@ package com.octopus.teamcity.opentelemetry.server.helpers;
 import io.opentelemetry.api.trace.Span;
 
 import javax.annotation.Nullable;
+import java.util.Date;
 
 public class NullOTELHelperImpl implements OTELHelper {
     @Override
     public boolean isReady() {
         return false;
+    }
+
+    @Override
+    public Date getLastUsed() {
+        return new Date();
     }
 
     @Override

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
@@ -3,9 +3,12 @@ package com.octopus.teamcity.opentelemetry.server.helpers;
 import io.opentelemetry.api.trace.Span;
 
 import javax.annotation.Nullable;
+import java.util.Date;
 
 public interface OTELHelper {
     boolean isReady();
+
+    Date getLastUsed();
 
     Span getOrCreateParentSpan(String buildId);
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
@@ -17,6 +17,7 @@ import io.opentelemetry.semconv.ServiceAttributes;
 import org.apache.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.Date;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -29,6 +30,7 @@ public class OTELHelperImpl implements OTELHelper {
     private final String helperName;
     @Nullable
     private final SdkMeterProvider meterProvider;
+    private Date lastAccessDate;
 
     public OTELHelperImpl(
             SpanProcessor spanProcessor,
@@ -49,20 +51,33 @@ public class OTELHelperImpl implements OTELHelper {
         this.tracer = this.openTelemetry.getTracer(PluginConstants.TRACER_INSTRUMENTATION_NAME);
         this.spanMap = new ConcurrentHashMap<>();
         this.meterProvider = meterProvider;
+        lastAccessDate = new Date();
     }
 
     @Override
     public boolean isReady() {
+        updateLastAccessDate();
         return this.openTelemetry != null && this.tracer != null && this.spanMap != null;
     }
 
     @Override
+    public Date getLastUsed() {
+        return this.lastAccessDate;
+    }
+
+    void updateLastAccessDate() {
+        this.lastAccessDate = new Date();
+    }
+
+    @Override
     public Span getOrCreateParentSpan(String buildId) {
+        updateLastAccessDate();
         return this.spanMap.computeIfAbsent(buildId, key -> this.tracer.spanBuilder(buildId).startSpan());
     }
 
     @Override
     public Span createSpan(String spanName, Span parentSpan, String parentSpanName) {
+        updateLastAccessDate();
         LOG.info("Creating child span " + spanName + " under parent " + parentSpanName);
         return this.spanMap.computeIfAbsent(spanName, key -> this.tracer
                 .spanBuilder(spanName)
@@ -72,6 +87,7 @@ public class OTELHelperImpl implements OTELHelper {
 
     @Override
     public Span createTransientSpan(String spanName, Span parentSpan, long startTime) {
+        updateLastAccessDate();
         return this.tracer.spanBuilder(spanName)
                 .setParent(Context.current().with(parentSpan))
                 .setStartTimestamp(startTime, TimeUnit.MILLISECONDS)
@@ -80,17 +96,20 @@ public class OTELHelperImpl implements OTELHelper {
 
     @Override
     public void removeSpan(String spanName) {
+        updateLastAccessDate();
         this.spanMap.remove(spanName);
     }
 
     @Override
     @Nullable
     public Span getSpan(String spanName) {
+        updateLastAccessDate();
         return this.spanMap.get(spanName);
     }
 
     @Override
     public void addAttributeToSpan(Span span, String attributeName, Object attributeValue) {
+        updateLastAccessDate();
         span.setAttribute(attributeName, attributeValue.toString());
     }
 

--- a/server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.Opentelemetry.xml
+++ b/server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.Opentelemetry.xml
@@ -9,7 +9,7 @@
     <bean class="com.octopus.teamcity.opentelemetry.server.ProjectConfigurationTab"/>
     <bean class="com.octopus.teamcity.opentelemetry.server.ProjectConfigurationSettingsController"/>
     <bean class="com.octopus.teamcity.opentelemetry.server.BuildOverviewExtensionController"/>
-    <bean class="com.octopus.teamcity.opentelemetry.server.helpers.HelperPerBuildOTELHelperFactory"/>
+    <bean class="com.octopus.teamcity.opentelemetry.server.helpers.HelperPerProjectOTELHelperFactory"/>
     <bean class="com.octopus.teamcity.opentelemetry.server.endpoints.OTELEndpointFactory"/>
     <bean class="com.octopus.teamcity.opentelemetry.server.BuildStorageManagerImpl"/>
 </beans>


### PR DESCRIPTION
# Background

We're still seeing thread leaks. See #368.

# Results

This PR adds adds the ability to evict OTELHelper entries from the cache.

By default, it checks every 5 mins, and evicts unused entries after 1 hour.

These values can be overridden by setting `teamcity.otel.helper.cleanup.timer.delay.ms` and `teamcity.otel.helper.cache.duration.ms` in the teamcity internal properties (Administration -> Diagnostics -> Internal Properties.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.