### PR TITLE
Fix the vendor url

### DIFF
--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -9,7 +9,7 @@
 
         <vendor>
             <name>Octopus Deploy Pty. Ltd.</name>
-            <url>https://octopusdeploy.com</url>
+            <url>https://octopus.com</url>
         </vendor>
     </info>
     <deployment use-separate-classloader="true" allow-runtime-reload="true" teamcity.development.shadowCopyClasses="true" node-responsibilities-aware="true" />


### PR DESCRIPTION
A simple fix, changing the vendor url from the old https://octopusdeploy.com to https://octopus.com

